### PR TITLE
bwogt/135/enh/remove-phone-field-from-user-accounts

### DIFF
--- a/app/Actions/Auth/Register/RegisterUserAction.php
+++ b/app/Actions/Auth/Register/RegisterUserAction.php
@@ -39,7 +39,6 @@ class RegisterUserAction
             'name' => $data->name,
             'email' => $data->email,
             'cpf' => $data->cpf,
-            'phone' => $data->phone,
             'password' => $data->password,
         ]);
     }

--- a/app/Actions/User/Update/UpdateUserAction.php
+++ b/app/Actions/User/Update/UpdateUserAction.php
@@ -21,7 +21,10 @@ class UpdateUserAction
                 return $user;
             });
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user);
+            throw new UpdateUserFailedException(
+                previous: $e,
+                context: ['user_id' => $user->id]
+            );
         }
     }
 
@@ -30,20 +33,11 @@ class UpdateUserAction
         $user->update([
             'name' => $data->name,
             'email' => $data->email,
-            'phone' => $data->phone,
         ]);
     }
 
     private function logSuccess(User $user): void
     {
         Log::info('User profile updated successfully.', ['user_id' => $user->id]);
-    }
-
-    private function handleFailure(Throwable $e, User $user): never
-    {
-        throw new UpdateUserFailedException(
-            previous: $e,
-            context: ['user_id' => $user->id]
-        );
     }
 }

--- a/app/Dto/Auth/RegisterUserDTO.php
+++ b/app/Dto/Auth/RegisterUserDTO.php
@@ -8,7 +8,6 @@ final class RegisterUserDTO
         public readonly string $name,
         public readonly string $email,
         public readonly string $cpf,
-        public readonly string $phone,
         public readonly string $password
     ) {}
 }

--- a/app/Dto/User/UpdateUserDTO.php
+++ b/app/Dto/User/UpdateUserDTO.php
@@ -7,6 +7,5 @@ final class UpdateUserDTO
     public function __construct(
         public readonly string $name,
         public readonly string $email,
-        public readonly string $phone,
     ) {}
 }

--- a/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -15,7 +15,6 @@ class RegisterUserRequest extends FormRequest
             name: $this->input('name'),
             email: $this->input('email'),
             cpf: $this->input('cpf'),
-            phone: $this->input('phone'),
             password: $this->input('password'),
         );
     }
@@ -26,7 +25,6 @@ class RegisterUserRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['bail', 'required', 'email', 'unique:users,email'],
             'cpf' => ['bail', 'required', 'regex:/^\d{3}\.\d{3}\.\d{3}\-\d{2}$/', new CpfRule, 'unique:users'],
-            'phone' => ['bail', 'required', 'regex:/^[(]\d{2}[)]\s\d{5}-\d{4}$/', 'unique:users,phone'],
             'password' => ['required', 'confirmed', 'max:255', Password::defaults()],
         ];
     }

--- a/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -25,7 +25,7 @@ class RegisterUserRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['bail', 'required', 'email', 'unique:users,email'],
             'cpf' => ['bail', 'required', 'regex:/^\d{3}\.\d{3}\.\d{3}\-\d{2}$/', new CpfRule, 'unique:users'],
-            'password' => ['required', 'confirmed', 'max:255', Password::defaults()],
+            'password' => ['required', Password::defaults()],
         ];
     }
 }

--- a/app/Http/Requests/User/SearchUserRequest.php
+++ b/app/Http/Requests/User/SearchUserRequest.php
@@ -11,7 +11,7 @@ class SearchUserRequest extends FormRequest
     {
         $email = $this->input('email');
 
-        return User::where('email', $email)->firstOrFail();
+        return User::whereEmail($email)->firstOrFail();
     }
 
     public function rules(): array
@@ -24,18 +24,6 @@ class SearchUserRequest extends FormRequest
                 'max:255',
                 'exists:users,email',
             ],
-        ];
-    }
-
-    /**
-     * Get the error messages for the defined validation rules.
-     *
-     * @return array<string, string>
-     */
-    public function messages(): array
-    {
-        return [
-            'email.exists' => trans('validation.custom.email.exists'),
         ];
     }
 }

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -13,7 +13,6 @@ class UpdateUserRequest extends FormRequest
         return new UpdateUserDTO(
             name: $this->input('name'),
             email: $this->input('email'),
-            phone: $this->input('phone'),
         );
     }
 
@@ -26,13 +25,6 @@ class UpdateUserRequest extends FormRequest
                 'required',
                 'email',
                 'max:255',
-                Rule::unique('users')
-                    ->ignore($this->user()->id),
-            ],
-            'phone' => [
-                'bail',
-                'required',
-                'regex:/^[(]\d{2}[)]\s\d{5}-\d{4}$/',
                 Rule::unique('users')
                     ->ignore($this->user()->id),
             ],

--- a/app/Http/Resources/User/UserPublicResource.php
+++ b/app/Http/Resources/User/UserPublicResource.php
@@ -21,7 +21,6 @@ class UserPublicResource extends JsonResource
             'id' => $this->id,
             'name' => $this->name,
             'cpf' => self::addAsteriskMaskForCpf($this->cpf),
-            'phone' => self::addAsteriskMaskForPhone($this->phone),
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Http/Resources/User/UserResource.php
+++ b/app/Http/Resources/User/UserResource.php
@@ -19,7 +19,6 @@ class UserResource extends JsonResource
             'name' => $this->name,
             'email' => $this->email,
             'cpf' => $this->cpf,
-            'phone' => $this->phone,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,
         ];

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,6 @@ class User extends Authenticatable
         'email',
         'password',
         'cpf',
-        'phone',
     ];
 
     /**

--- a/app/Traits/StringMasks.php
+++ b/app/Traits/StringMasks.php
@@ -8,28 +8,23 @@ trait StringMasks
 {
     public function addAsteriskMaskForImei(string $imei): string
     {
-        if (strlen($imei) != 15)
+        if (strlen($imei) != 15) {
             throw new Exception('The imei must have 15 digits!');
+        }
 
         $asterisks = str_repeat('*', 9);
+
         return substr_replace($imei, $asterisks, 3, 9);
     }
 
     public function addAsteriskMaskForCpf(string $cpf): string
     {
-        if (strlen($cpf) != 14)
+        if (strlen($cpf) != 14) {
             throw new Exception('The cpf must have 14 digits!');
+        }
 
         $asterisks = str_repeat('*', 10);
+
         return substr_replace($cpf, $asterisks, 2, 10);
-    }
-
-    public function addAsteriskMaskForPhone(string $phone): string
-    {
-        if (strlen($phone) != 15)
-            throw new Exception('The phone must have 15 characters!');
-
-        $asterisks = str_repeat('*', 8);
-        return substr_replace($phone, $asterisks, 4, 8);
     }
 }

--- a/database/data/development/users.json
+++ b/database/data/development/users.json
@@ -3,28 +3,24 @@
         "name": "Monkey D. Luffy",
         "email": "user1@example.com",
         "password": "12345678",
-        "cpf": "273.623.457-04",
-        "phone": "(42) 99999-0001"
+        "cpf": "273.623.457-04"
     },
     {
         "name": "Roronoa Zoro",
         "email": "user2@example.com",
         "password": "12345678",
-        "cpf": "548.074.611-17",
-        "phone": "(42) 99999-0002"
+        "cpf": "548.074.611-17"
     },
     {
         "name": "Nami",
         "email": "user3@example.com",
         "password": "12345678",
-        "cpf": "354.273.593-03",
-        "phone": "(42) 99999-0003"
+        "cpf": "354.273.593-03"
     },
     {
         "name": "Nico Robin",
         "email": "user4@example.com",
         "password": "12345678",
-        "cpf": "323.699.455-08",
-        "phone": "(42) 99999-0004"
+        "cpf": "323.699.455-08"
     }
 ]

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -22,10 +22,9 @@ class UserFactory extends Factory
             'name' => mb_convert_case(fake()->name(), MB_CASE_TITLE),
             'email' => strtolower(str_replace(' ', '', fake()->unique()->safeEmail())),
             'email_verified_at' => now(),
-            'password' =>  Hash::make('password'),
+            'password' => Hash::make('password'),
             'remember_token' => Str::random(10),
             'cpf' => fake()->unique()->cpf(),
-            'phone' => fake()->unique()->cellPhoneNumber()
         ];
     }
 

--- a/database/migrations/2026_06_03_173714_drop_phone_column_from_users_table.php
+++ b/database/migrations/2026_06_03_173714_drop_phone_column_from_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('phone');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('phone', 20)->unique()->nullable();
+        });
+    }
+};

--- a/database/seeders/Development/UserSeeder.php
+++ b/database/seeders/Development/UserSeeder.php
@@ -32,7 +32,6 @@ class UserSeeder extends Seeder
             'name' => $rawUser->name,
             'email' => $rawUser->email,
             'cpf' => $rawUser->cpf,
-            'phone' => $rawUser->phone,
             'password' => $rawUser->password,
         ]);
     }

--- a/tests/Feature/Controllers/Auth/Login/LoginAccessTest.php
+++ b/tests/Feature/Controllers/Auth/Login/LoginAccessTest.php
@@ -14,13 +14,13 @@ class LoginAccessTest extends LoginTestSetUp
             'password' => 'password',
         ])
             ->assertOk()
-            ->assertJson(fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::SUCCESS)
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::SUCCESS)
                 ->where('message.text', trans('actions.auth.success.login'))
                 ->where('data.user.id', $this->user->id)
                 ->where('data.user.name', $this->user->name)
                 ->where('data.user.email', $this->user->email)
                 ->where('data.user.cpf', $this->user->cpf)
-                ->where('data.user.phone', $this->user->phone)
                 ->has('data.token')
                 ->missing('data.user.password')
             );

--- a/tests/Feature/Controllers/Auth/Register/RegisterUserAccessTest.php
+++ b/tests/Feature/Controllers/Auth/Register/RegisterUserAccessTest.php
@@ -9,16 +9,16 @@ class RegisterUserAccessTest extends RegisterUserTestSetUp
 {
     public function test_should_an_unauthenticated_user_be_able_to_register(): void
     {
-        $data = $this->validUserData();
+        $data = $this->data();
 
         $this->postJson($this->route(), $data)
             ->assertCreated()
-            ->assertJson(fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::SUCCESS)
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::SUCCESS)
                 ->where('message.text', trans('actions.auth.success.register'))
                 ->where('data.user.name', $data['name'])
                 ->where('data.user.email', $data['email'])
                 ->where('data.user.cpf', $data['cpf'])
-                ->where('data.user.phone', $data['phone'])
                 ->has('data.token')
                 ->missing('data.user.password')
             );

--- a/tests/Feature/Controllers/Auth/Register/RegisterUserRulesTest.php
+++ b/tests/Feature/Controllers/Auth/Register/RegisterUserRulesTest.php
@@ -13,7 +13,8 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
         $this->postJson($this->route())
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.name.0', trans('validation.required', [
                         'attribute' => trans('validation.attributes.name'),
@@ -24,9 +25,6 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
                     ->where('errors.cpf.0', trans('validation.required', [
                         'attribute' => 'cpf',
                     ]))
-                    ->where('errors.phone.0', trans('validation.required', [
-                        'attribute' => trans('validation.attributes.phone'),
-                    ]))
                     ->where('errors.password.0', trans('validation.required', [
                         'attribute' => trans('validation.attributes.password'),
                     ]))
@@ -35,10 +33,11 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_name_field_value_is_longer_than_255_characters(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['name' => Str::random(256)]))
+        $this->postJson($this->route(), $this->data(['name' => Str::random(256)]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.name.0', trans('validation.max.string', [
                         'max' => 255,
@@ -49,10 +48,11 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_email_field_value_is_not_a_valid_email(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['email' => Str::random(10)]))
+        $this->postJson($this->route(), $this->data(['email' => Str::random(10)]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.email.0', trans('validation.email', [
                         'attribute' => 'email',
@@ -62,10 +62,11 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_email_field_value_exists_in_the_database(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['email' => $this->user->email]))
+        $this->postJson($this->route(), $this->data(['email' => $this->user->email]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.email.0', trans('validation.unique', [
                         'attribute' => 'email',
@@ -75,10 +76,11 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_cpf_field_value_has_an_invalid_format(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['cpf' => Str::random(14)]))
+        $this->postJson($this->route(), $this->data(['cpf' => Str::random(14)]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.cpf.0', trans('validation.regex', [
                         'attribute' => 'cpf',
@@ -88,39 +90,14 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_cpf_field_values_exists_in_the_database(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['cpf' => $this->user->cpf]))
+        $this->postJson($this->route(), $this->data(['cpf' => $this->user->cpf]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.cpf.0', trans('validation.unique', [
                         'attribute' => 'cpf',
-                    ]))
-            );
-    }
-
-    public function test_should_return_an_error_when_the_phone_param_is_invalid(): void
-    {
-        $this->postJson($this->route(), $this->validUserData(['phone' => Str::random(15)]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.phone.0', trans('validation.regex', [
-                        'attribute' => trans('validation.attributes.phone'),
-                    ]))
-            );
-    }
-
-    public function test_should_return_an_error_when_the_phone_field_value_exists_in_the_database(): void
-    {
-        $this->postJson($this->route(), $this->validUserData(['phone' => $this->user->phone]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.phone.0', trans('validation.unique', [
-                        'attribute' => trans('validation.attributes.phone'),
                     ]))
             );
     }
@@ -129,13 +106,14 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
     {
         $password = Str::random(7);
 
-        $this->postJson($this->route(), $this->validUserData([
+        $this->postJson($this->route(), $this->data([
             'password' => $password,
             'password_confirmation' => $password,
         ]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.password.0', trans('validation.min.string', [
                         'attribute' => trans('validation.attributes.password'),
@@ -148,13 +126,14 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
     {
         $password = Str::random(256);
 
-        $this->postJson($this->route(), $this->validUserData([
+        $this->postJson($this->route(), $this->data([
             'password' => $password,
             'password_confirmation' => $password,
         ]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.password.0', trans('validation.max.string', [
                         'attribute' => trans('validation.attributes.password'),
@@ -165,10 +144,11 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_password_is_different_from_the_password_confirmation(): void
     {
-        $this->postJson($this->route(), $this->validUserData(['password_confirmation' => Str::random(8)]))
+        $this->postJson($this->route(), $this->data(['password_confirmation' => Str::random(8)]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.password.0', trans('validation.confirmed', [
                         'attribute' => trans('validation.attributes.password'),

--- a/tests/Feature/Controllers/Auth/Register/RegisterUserRulesTest.php
+++ b/tests/Feature/Controllers/Auth/Register/RegisterUserRulesTest.php
@@ -8,7 +8,7 @@ use Illuminate\Testing\Fluent\AssertableJson;
 
 class RegisterUserRulesTest extends RegisterUserTestSetUp
 {
-    public function test_should_return_all_errors_when_the_required_fields_are_null_values(): void
+    public function test_should_errors_when_the_required_fields_are_missing(): void
     {
         $this->postJson($this->route())
             ->assertUnprocessable()
@@ -33,59 +33,63 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
 
     public function test_should_return_an_error_when_the_name_field_value_is_longer_than_255_characters(): void
     {
-        $this->postJson($this->route(), $this->data(['name' => Str::random(256)]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.name.0', trans('validation.max.string', [
-                        'max' => 255,
-                        'attribute' => trans('validation.attributes.name'),
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['name' => Str::random(256)])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.name.0', trans('validation.max.string', [
+                    'max' => 255,
+                    'attribute' => trans('validation.attributes.name'),
+                ]))
+        );
     }
 
     public function test_should_return_an_error_when_the_email_field_value_is_not_a_valid_email(): void
     {
-        $this->postJson($this->route(), $this->data(['email' => Str::random(10)]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.email.0', trans('validation.email', [
-                        'attribute' => 'email',
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['email' => Str::random(10)])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.email.0', trans('validation.email', [
+                    'attribute' => 'email',
+                ]))
+        );
     }
 
     public function test_should_return_an_error_when_the_email_field_value_exists_in_the_database(): void
     {
-        $this->postJson($this->route(), $this->data(['email' => $this->user->email]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.email.0', trans('validation.unique', [
-                        'attribute' => 'email',
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['email' => $this->user->email])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.email.0', trans('validation.unique', [
+                    'attribute' => 'email',
+                ]))
+        );
     }
 
     public function test_should_return_an_error_when_the_cpf_field_value_has_an_invalid_format(): void
     {
-        $this->postJson($this->route(), $this->data(['cpf' => Str::random(14)]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.cpf.0', trans('validation.regex', [
-                        'attribute' => 'cpf',
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['cpf' => Str::random(14)])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.cpf.0', trans('validation.regex', [
+                    'attribute' => 'cpf',
+                ]))
+        );
     }
 
     public function test_should_return_an_error_when_the_cpf_field_values_exists_in_the_database(): void
@@ -102,57 +106,35 @@ class RegisterUserRulesTest extends RegisterUserTestSetUp
             );
     }
 
-    public function test_should_return_an_error_when_the_password_field_value_is_less_than_8_characters_longs(): void
+    public function test_should_return_an_error_when_the_password_field_value_is_less_than_8_characters(): void
     {
-        $password = Str::random(7);
-
-        $this->postJson($this->route(), $this->data([
-            'password' => $password,
-            'password_confirmation' => $password,
-        ]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.password.0', trans('validation.min.string', [
-                        'attribute' => trans('validation.attributes.password'),
-                        'min' => 8,
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['password' => Str::random(7)])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.password.0', trans('validation.min.string', [
+                    'attribute' => trans('validation.attributes.password'),
+                    'min' => 8,
+                ]))
+        );
     }
 
     public function test_should_return_an_error_when_the_password_field_value_is_longer_than_255_characters(): void
     {
-        $password = Str::random(256);
-
-        $this->postJson($this->route(), $this->data([
-            'password' => $password,
-            'password_confirmation' => $password,
-        ]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.password.0', trans('validation.max.string', [
-                        'attribute' => trans('validation.attributes.password'),
-                        'max' => 255,
-                    ]))
-            );
-    }
-
-    public function test_should_return_an_error_when_the_password_is_different_from_the_password_confirmation(): void
-    {
-        $this->postJson($this->route(), $this->data(['password_confirmation' => Str::random(8)]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json
-                    ->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.password.0', trans('validation.confirmed', [
-                        'attribute' => trans('validation.attributes.password'),
-                    ]))
-            );
+        $this->postJson(
+            $this->route(),
+            $this->data(['password' => Str::random(256)])
+        )->assertUnprocessable()->assertJson(
+            fn (AssertableJson $json) => $json
+                ->where('message.type', FlashMessageType::ERROR)
+                ->where('message.text', trans('flash_messages.errors'))
+                ->where('errors.password.0', trans('validation.max.string', [
+                    'attribute' => trans('validation.attributes.password'),
+                    'max' => 255,
+                ]))
+        );
     }
 }

--- a/tests/Feature/Controllers/Auth/Register/RegisterUserTestSetUp.php
+++ b/tests/Feature/Controllers/Auth/Register/RegisterUserTestSetUp.php
@@ -24,13 +24,12 @@ abstract class RegisterUserTestSetUp extends TestCase
         return route('api.auth.register');
     }
 
-    protected function validUserData(array $overrides = []): array
+    protected function data(array $overrides = []): array
     {
         return array_merge([
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'cpf' => fake()->unique()->cpf(),
-            'phone' => fake()->unique()->cellPhoneNumber(),
             'password' => 'password',
             'password_confirmation' => 'password',
         ], $overrides);

--- a/tests/Feature/Controllers/DeviceController/View/ViewDeviceResponseTest.php
+++ b/tests/Feature/Controllers/DeviceController/View/ViewDeviceResponseTest.php
@@ -26,7 +26,6 @@ class ViewDeviceResponseTest extends ViewDeviceTestSetUp
                     ->where('user.id', $this->user->id)
                     ->where('user.name', $this->user->name)
                     ->where('user.cpf', $this->user->cpf)
-                    ->where('user.phone', $this->user->phone)
                     ->has('user.created_at')
                     ->has('user.updated_at')
                     ->missing('user.password')

--- a/tests/Feature/Controllers/DeviceSharingController/View/ViewDeviceByTokenResponseTest.php
+++ b/tests/Feature/Controllers/DeviceSharingController/View/ViewDeviceByTokenResponseTest.php
@@ -39,10 +39,10 @@ class ViewDeviceByTokenResponseTest extends ViewDeviceByTokenTestSetUp
         $this->getJson($this->route($this->deviceSharingToken->token))
             ->assertOk()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('user.id', $this->user->id)
+                fn (AssertableJson $json) => $json
+                    ->where('user.id', $this->user->id)
                     ->where('user.name', $this->user->name)
                     ->where('user.cpf', $this->addAsteriskMaskForCpf($this->user->cpf))
-                    ->where('user.phone', $this->addAsteriskMaskForPhone($this->user->phone))
                     ->has('user.created_at')
                     ->etc()
             );

--- a/tests/Feature/Controllers/UserController/Devices/UserDevicesResponseTest.php
+++ b/tests/Feature/Controllers/UserController/Devices/UserDevicesResponseTest.php
@@ -15,7 +15,8 @@ class UserDevicesResponseTest extends UserDevicesTestSetUp
             ->assertOk()
             ->assertJson(
                 fn (AssertableJson $json) => $json->has(1)
-                    ->first(fn (AssertableJson $json) => $json->where('id', $this->device->id)
+                    ->first(fn (AssertableJson $json) => $json
+                        ->where('id', $this->device->id)
                         ->where('color', $this->device->color)
                         ->where('imei_1', $this->device->imei_1)
                         ->where('imei_2', $this->device->imei_2)
@@ -27,7 +28,6 @@ class UserDevicesResponseTest extends UserDevicesTestSetUp
                         ->where('user.id', $this->user->id)
                         ->where('user.name', $this->user->name)
                         ->where('user.cpf', $this->user->cpf)
-                        ->where('user.phone', $this->user->phone)
                         ->has('user.created_at')
                         ->has('user.updated_at')
                         ->missing('user.password')

--- a/tests/Feature/Controllers/UserController/Search/SearchUserByEmailResponseTest.php
+++ b/tests/Feature/Controllers/UserController/Search/SearchUserByEmailResponseTest.php
@@ -14,10 +14,10 @@ class SearchUserByEmailResponseTest extends SearchUserByEmailTestSetUp
         $this->getJson($this->route(email: $this->targetUser->email))
             ->assertOk()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('id', $this->targetUser->id)
+                fn (AssertableJson $json) => $json
+                    ->where('id', $this->targetUser->id)
                     ->where('name', $this->targetUser->name)
                     ->where('cpf', $this->addAsteriskMaskForCpf($this->targetUser->cpf))
-                    ->where('phone', $this->addAsteriskMaskForPhone($this->targetUser->phone))
                     ->has('created_at')
                     ->missing('password')
             );

--- a/tests/Feature/Controllers/UserController/Update/UpdateUserRuleTest.php
+++ b/tests/Feature/Controllers/UserController/Update/UpdateUserRuleTest.php
@@ -20,16 +20,14 @@ final class UpdateUserRuleTest extends UpdateUserTestSetUp
         $this->patchJson($this->route())
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.name.0', trans('validation.required', [
                         'attribute' => trans('validation.attributes.name'),
                     ]))
                     ->where('errors.email.0', trans('validation.required', [
                         'attribute' => 'email',
-                    ]))
-                    ->where('errors.phone.0', trans('validation.required', [
-                        'attribute' => trans('validation.attributes.phone'),
                     ]))
             );
     }
@@ -39,7 +37,8 @@ final class UpdateUserRuleTest extends UpdateUserTestSetUp
         $this->patchJson($this->route(), $this->data(['name' => Str::random(256)]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.name.0', trans('validation.max.string', [
                         'attribute' => trans('validation.attributes.name'),
@@ -53,7 +52,8 @@ final class UpdateUserRuleTest extends UpdateUserTestSetUp
         $this->patchJson($this->route(), $this->data(['email' => 'abc']))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.email.0', trans('validation.email', [
                         'attribute' => 'email',
@@ -66,36 +66,11 @@ final class UpdateUserRuleTest extends UpdateUserTestSetUp
         $this->patchJson($this->route(), $this->data(['email' => $this->anotherUser->email]))
             ->assertUnprocessable()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
+                fn (AssertableJson $json) => $json
+                    ->where('message.type', FlashMessageType::ERROR)
                     ->where('message.text', trans('flash_messages.errors'))
                     ->where('errors.email.0', trans('validation.unique', [
                         'attribute' => 'email',
-                    ]))
-            );
-    }
-
-    public function test_should_return_an_error_when_the_phone_field_is_not_unique(): void
-    {
-        $this->patchJson($this->route(), $this->data(['phone' => $this->anotherUser->phone]))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.phone.0', trans('validation.unique', [
-                        'attribute' => trans('validation.attributes.phone'),
-                    ]))
-            );
-    }
-
-    public function test_should_return_an_error_when_the_phone_field_regex_is_not_valid(): void
-    {
-        $this->patchJson($this->route(), $this->data(['phone' => '42999999999']))
-            ->assertUnprocessable()
-            ->assertJson(
-                fn (AssertableJson $json) => $json->where('message.type', FlashMessageType::ERROR)
-                    ->where('message.text', trans('flash_messages.errors'))
-                    ->where('errors.phone.0', trans('validation.regex', [
-                        'attribute' => trans('validation.attributes.phone'),
                     ]))
             );
     }

--- a/tests/Feature/Controllers/UserController/Update/UpdateUserTestSetUp.php
+++ b/tests/Feature/Controllers/UserController/Update/UpdateUserTestSetUp.php
@@ -38,7 +38,6 @@ abstract class UpdateUserTestSetUp extends TestCase
         return array_merge([
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'phone' => fake()->unique()->cellPhoneNumber(),
         ], $overrides);
     }
 }

--- a/tests/Feature/Controllers/UserController/View/ViewUserResponseTest.php
+++ b/tests/Feature/Controllers/UserController/View/ViewUserResponseTest.php
@@ -14,11 +14,11 @@ class ViewUserResponseTest extends ViewUserTestSetUp
         $this->getJson($this->route())
             ->assertOk()
             ->assertJson(
-                fn (AssertableJson $json) => $json->where('id', $this->user->id)
+                fn (AssertableJson $json) => $json
+                    ->where('id', $this->user->id)
                     ->where('name', $this->user->name)
                     ->where('email', $this->user->email)
                     ->where('cpf', $this->user->cpf)
-                    ->where('phone', $this->user->phone)
                     ->has('created_at')
                     ->has('updated_at')
                     ->missing('password')

--- a/tests/Unit/Actions/Auth/Register/RegisterUserActionTest.php
+++ b/tests/Unit/Actions/Auth/Register/RegisterUserActionTest.php
@@ -24,7 +24,6 @@ class RegisterUserActionTest extends RegisterUserActionTestSetUp
             'name' => $this->data->name,
             'email' => $this->data->email,
             'cpf' => $this->data->cpf,
-            'phone' => $this->data->phone,
         ]);
     }
 
@@ -32,7 +31,8 @@ class RegisterUserActionTest extends RegisterUserActionTestSetUp
     {
         $this->expectException(RegisterUserFailedException::class);
 
-        DB::shouldReceive('transaction')->once()
+        DB::shouldReceive('transaction')
+            ->once()
             ->andThrow(new Exception('Simulates a transaction error',
                 Response::HTTP_INTERNAL_SERVER_ERROR
             ));

--- a/tests/Unit/Actions/Auth/Register/RegisterUserActionTestSetUp.php
+++ b/tests/Unit/Actions/Auth/Register/RegisterUserActionTestSetUp.php
@@ -33,7 +33,6 @@ abstract class RegisterUserActionTestSetUp extends TestCase
             name: fake()->name(),
             email: fake()->unique()->safeEmail(),
             cpf: fake()->unique()->cpf(),
-            phone: fake()->unique()->cellPhoneNumber(),
             password: 'password',
         );
     }

--- a/tests/Unit/Actions/User/Update/UpdateUserActionTest.php
+++ b/tests/Unit/Actions/User/Update/UpdateUserActionTest.php
@@ -24,7 +24,6 @@ final class UpdateUserActionTest extends UpdateUserActionTestSetUp
             'id' => $this->user->id,
             'name' => $this->data->name,
             'email' => $this->data->email,
-            'phone' => $this->data->phone,
         ]);
     }
 
@@ -32,7 +31,8 @@ final class UpdateUserActionTest extends UpdateUserActionTestSetUp
     {
         $this->expectException(UpdateUserFailedException::class);
 
-        DB::shouldReceive('transaction')->once()
+        DB::shouldReceive('transaction')
+            ->once()
             ->andThrow(new Exception('Simulates a transaction error',
                 Response::HTTP_INTERNAL_SERVER_ERROR
             ));

--- a/tests/Unit/Actions/User/Update/UpdateUserActionTestSetUp.php
+++ b/tests/Unit/Actions/User/Update/UpdateUserActionTestSetUp.php
@@ -41,7 +41,6 @@ abstract class UpdateUserActionTestSetUp extends TestCase
         $this->data = new UpdateUserDTO(
             name: fake()->name(),
             email: fake()->unique()->safeEmail(),
-            phone: fake()->unique()->cellPhoneNumber(),
         );
     }
 }


### PR DESCRIPTION
## Description
This PR simplifies the user registration and account management flows by removing the phone attribute and eliminating the password confirmation requirement during registration.

## 🔧 What was done
- Removed the `phone` column from the `users`
- Removed phone handling from user registration and profile update flows; 
- Removed the `password_confirmation` requirement from user registration;
- Removed phone validation rules, DTO mappings, and model attributes;

## 🧪 How to test
Step-by-step instructions for the reviewer to test the changes (e.g., commands to run, tests to be performed,
specific endpoints to call, or UI flows to follow).

1. Setup the environment
~~~bash
# Start development environment
docker compose --profile web up -d --build
~~~

~~~bash 
# Start testing environment
docker compose --profile test --env-file=.env.testing up -d --build
~~~

2. Apply the database migrations
~~~bash
docker compose exec app php artisan migrate
~~~

3. Run the automated test suite
~~~bash
docker compose exec app_test php artisan test
~~~

4. Validate user registration
- Register a new user without providing the phone field;
- Register a new user without providing the password_confirmation field;
- Confirm that the registration succeeds and the user is authenticated normally.

5. Validate user profile endpoints
- Retrieve user information and confirm that the `phone` attribute is no longer present in the API responses;
- Update a user profile and confirm that phone-related attributes are no longer accepted.

## 📘 Docs 
To view the API documentation locally, go to: `http://localhost/docs/api#/`

## 🔗 Related Issue
Closes #135 