### PR TITLE
bwogt/137/enh/email-validation

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -10,30 +10,22 @@ use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Requests\Auth\RegisterUserRequest;
 use App\Http\Resources\Auth\LoginResource;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Resources\Json\JsonResource;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthController extends Controller
 {
     public function register(RegisterUserRequest $request, RegisterUserAction $action): JsonResponse
     {
-        $loginDto = $action($request->toDto());
-
         return response()->json(
-            FlashMessage::success(trans('actions.auth.success.register'))
-                ->merge(['data' => new LoginResource($loginDto)]),
+            new LoginResource($action($request->toDto())),
             Response::HTTP_CREATED
         );
     }
 
-    public function login(LoginRequest $request, LoginAction $action): JsonResponse
+    public function login(LoginRequest $request, LoginAction $action): JsonResource
     {
-        $loginDto = $action($request->toDto());
-
-        return response()->json(
-            FlashMessage::success(trans('actions.auth.success.login'))
-                ->merge(['data' => new LoginResource($loginDto)]),
-            Response::HTTP_OK
-        );
+        return new LoginResource($action($request->toDto()));
     }
 
     public function logout(): JsonResponse

--- a/app/Http/Controllers/User/UserController.php
+++ b/app/Http/Controllers/User/UserController.php
@@ -22,10 +22,11 @@ class UserController extends Controller
      */
     public function update(UpdateUserRequest $request, UpdateUserAction $action): Response
     {
-        $action($request->user(), $request->toDto());
+        $user = $action($request->user(), $request->toDto());
 
-        return response()->json(FlashMessage::success(
-            trans('actions.user.success.update')),
+        return response()->json(
+            FlashMessage::success(trans('actions.user.success.update'))
+                ->merge(['user' => new UserResource($user)]),
             Response::HTTP_OK
         );
     }

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -18,8 +18,17 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
-            'password' => ['required', 'string', 'max:255'],
+            'email' => [
+                'bail',
+                'required',
+                'string',
+                'email:filter',
+            ],
+            'password' => [
+                'required',
+                'string',
+                'max:255',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -22,10 +22,28 @@ class RegisterUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['bail', 'required', 'email', 'unique:users,email'],
-            'cpf' => ['bail', 'required', 'regex:/^\d{3}\.\d{3}\.\d{3}\-\d{2}$/', new CpfRule, 'unique:users'],
-            'password' => ['required', Password::defaults()],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+            'email' => [
+                'bail',
+                'required',
+                'email:filter',
+                'unique:users,email',
+            ],
+            'cpf' => [
+                'bail',
+                'required',
+                'regex:/^\d{3}\.\d{3}\.\d{3}\-\d{2}$/',
+                new CpfRule,
+                'unique:users',
+            ],
+            'password' => [
+                'required',
+                Password::defaults(),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Device/CreateDeviceTransferRequest.php
+++ b/app/Http/Requests/Device/CreateDeviceTransferRequest.php
@@ -27,7 +27,12 @@ class CreateDeviceTransferRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'target_user_id' => ['bail', 'required', 'integer', 'exists:users,id'],
+            'target_user_id' => [
+                'bail',
+                'required',
+                'integer',
+                'exists:users,id',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Device/RegisterDeviceRequest.php
+++ b/app/Http/Requests/Device/RegisterDeviceRequest.php
@@ -21,11 +21,37 @@ class RegisterDeviceRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'device_model_id' => ['bail', 'required', 'integer', 'exists:device_models,id'],
-            'access_key' => ['bail', 'required', 'digits:44', 'unique:invoices,access_key'],
-            'color' => ['bail', 'required', 'max:255'],
-            'imei_1' => ['bail', 'required', 'digits:15', 'different:imei_2', 'unique:devices,imei_1', 'unique:devices,imei_2'],
-            'imei_2' => ['bail', 'required', 'digits:15', 'unique:devices,imei_1', 'unique:devices,imei_2'],
+            'device_model_id' => [
+                'bail',
+                'required',
+                'integer',
+                'exists:device_models,id',
+            ],
+            'access_key' => [
+                'bail',
+                'required',
+                'digits:44',
+                'unique:invoices,access_key',
+            ],
+            'color' => [
+                'bail',
+                'required',
+                'max:255',
+            ],
+            'imei_1' => [
+                'bail',
+                'required',
+                'digits:15',
+                'different:imei_2',
+                'unique:devices,imei_1',
+                'unique:devices,imei_2'],
+            'imei_2' => [
+                'bail',
+                'required',
+                'digits:15',
+                'unique:devices,imei_1',
+                'unique:devices,imei_2',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Device/StartDeviceValidationRequest.php
+++ b/app/Http/Requests/Device/StartDeviceValidationRequest.php
@@ -24,9 +24,21 @@ class StartDeviceValidationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'cpf' => ['required', 'string', 'max:16'],
-            'name' => ['required', 'string', 'max:255'],
-            'products' => ['required', 'string', 'max:16000'],
+            'cpf' => [
+                'required',
+                'string',
+                'max:16',
+            ],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+            'products' => [
+                'required',
+                'string',
+                'max:16000',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/PasswordReset/CheckPasswordResetCodeRequest.php
+++ b/app/Http/Requests/PasswordReset/CheckPasswordResetCodeRequest.php
@@ -20,8 +20,8 @@ class CheckPasswordResetCodeRequest extends FormRequest
     {
         return [
             'code' => [
-                'required', 
-                'digits:6'
+                'required',
+                'digits:6',
             ],
             'email' => [
                 'bail',

--- a/app/Http/Requests/PasswordReset/CheckPasswordResetCodeRequest.php
+++ b/app/Http/Requests/PasswordReset/CheckPasswordResetCodeRequest.php
@@ -19,8 +19,16 @@ class CheckPasswordResetCodeRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'code' => ['required', 'digits:6'],
-            'email' => ['required', 'string', 'email'],
+            'code' => [
+                'required', 
+                'digits:6'
+            ],
+            'email' => [
+                'bail',
+                'required',
+                'string',
+                'email:filter',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/PasswordReset/ResetPasswordRequest.php
+++ b/app/Http/Requests/PasswordReset/ResetPasswordRequest.php
@@ -20,9 +20,20 @@ class ResetPasswordRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'code' => ['required', 'digits:6'],
-            'email' => ['required', 'string', 'email'],
-            'password' => ['required', Password::defaults()],
+            'code' => [
+                'required',
+                'digits:6',
+            ],
+            'email' => [
+                'bail',
+                'required',
+                'string',
+                'email:filter',
+            ],
+            'password' => [
+                'required',
+                Password::defaults(),
+            ],
         ];
     }
 }

--- a/app/Http/Requests/PasswordReset/StartPasswordResetRequest.php
+++ b/app/Http/Requests/PasswordReset/StartPasswordResetRequest.php
@@ -14,7 +14,12 @@ class StartPasswordResetRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => ['required', 'string', 'email'],
+            'email' => [
+                'bail',
+                'required',
+                'string',
+                'email:filter',
+            ],
         ];
     }
 }

--- a/app/Http/Requests/User/SearchUserRequest.php
+++ b/app/Http/Requests/User/SearchUserRequest.php
@@ -20,8 +20,7 @@ class SearchUserRequest extends FormRequest
             'email' => [
                 'bail',
                 'required',
-                'email',
-                'max:255',
+                'email:filter',
                 'exists:users,email',
             ],
         ];

--- a/app/Http/Requests/User/UpdateUserRequest.php
+++ b/app/Http/Requests/User/UpdateUserRequest.php
@@ -19,12 +19,16 @@ class UpdateUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+            ],
             'email' => [
                 'bail',
                 'required',
-                'email',
-                'max:255',
+                'string',
+                'email:filter',
                 Rule::unique('users')
                     ->ignore($this->user()->id),
             ],

--- a/lang/pt_BR/actions.php
+++ b/lang/pt_BR/actions.php
@@ -15,7 +15,7 @@ return [
     ],
     'password_reset' => [
         'success' => [
-            'start' => 'Se houver uma conta associada a este e-mail, enviaremos um código de redefinição.',
+            'start' => 'Enviamos um código de redefinição de senha para o seu e-mail.',
             'check_code' => 'Código de redefinição de senha verificado com sucesso.',
             'reset' => 'Senha redefinida com sucesso.',
         ],
@@ -23,7 +23,7 @@ return [
             'start' => 'Ocorreu um erro ao solicitar a redefinição de senha.',
             'check_code' => 'Ocorreu um erro ao verificar o código de redefinição de senha.',
             'block' => 'Ocorreu um erro ao bloquear a redefinição de senha.',
-            'reset' => 'Ocorreu um erro ao redefinir a senha.',
+            'reset' => 'Ocorreu um erro ao atualizar a senha.',
         ],
     ],
     'user' => [

--- a/tests/Feature/Controllers/Auth/Login/LoginAccessTest.php
+++ b/tests/Feature/Controllers/Auth/Login/LoginAccessTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Controllers\Auth\Login;
 
-use App\Enums\FlashMessage\FlashMessageType;
 use Illuminate\Testing\Fluent\AssertableJson;
 
 class LoginAccessTest extends LoginTestSetUp
@@ -15,14 +14,12 @@ class LoginAccessTest extends LoginTestSetUp
         ])
             ->assertOk()
             ->assertJson(fn (AssertableJson $json) => $json
-                ->where('message.type', FlashMessageType::SUCCESS)
-                ->where('message.text', trans('actions.auth.success.login'))
-                ->where('data.user.id', $this->user->id)
-                ->where('data.user.name', $this->user->name)
-                ->where('data.user.email', $this->user->email)
-                ->where('data.user.cpf', $this->user->cpf)
-                ->has('data.token')
-                ->missing('data.user.password')
+                ->where('user.id', $this->user->id)
+                ->where('user.name', $this->user->name)
+                ->where('user.email', $this->user->email)
+                ->where('user.cpf', $this->user->cpf)
+                ->missing('user.password')
+                ->has('token')
             );
     }
 }

--- a/tests/Feature/Controllers/Auth/Register/RegisterUserAccessTest.php
+++ b/tests/Feature/Controllers/Auth/Register/RegisterUserAccessTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Controllers\Auth\Register;
 
-use App\Enums\FlashMessage\FlashMessageType;
 use Illuminate\Testing\Fluent\AssertableJson;
 
 class RegisterUserAccessTest extends RegisterUserTestSetUp
@@ -14,13 +13,11 @@ class RegisterUserAccessTest extends RegisterUserTestSetUp
         $this->postJson($this->route(), $data)
             ->assertCreated()
             ->assertJson(fn (AssertableJson $json) => $json
-                ->where('message.type', FlashMessageType::SUCCESS)
-                ->where('message.text', trans('actions.auth.success.register'))
-                ->where('data.user.name', $data['name'])
-                ->where('data.user.email', $data['email'])
-                ->where('data.user.cpf', $data['cpf'])
-                ->has('data.token')
-                ->missing('data.user.password')
+                ->where('user.name', $data['name'])
+                ->where('user.email', $data['email'])
+                ->where('user.cpf', $data['cpf'])
+                ->missing('user.password')
+                ->has('token')
             );
     }
 }


### PR DESCRIPTION
## Description
This PR addresses an inconsistency where the backend accepted structurally invalid email addresses (e.g., `user@example`), which were later rejected by the frontend's Zod validation. The email validation rules have been tightened to align with the frontend's expectations, preventing invalid data from being persisted.

Additionally, two complementary improvements were made to enhance the user experience and reduce unnecessary frontend overhead:
- The password reset code message has been updated for better clarity
- The profile update endpoint now returns the updated user data, eliminating an extra frontend request

These changes are grouped together as they were identified and addressed during the same development cycle.


## 🔧 What was done

- Replaced the default `email` validation rule with `email:filter` in all applicable Form Requests (registration, profile update, password reset request)
- Enforced a stricter email format aligned with PHP's `FILTER_VALIDATE_EMAIL`
- Added or updated tests to cover rejection of invalid email formats such as `user@example`
- Updated the flash message or email notification content for the password reset code to provide clearer and more actionable feedback to users
- Removed the unnecessary success flash message displayed after user login to reduce UI clutter
- Updated the profile update endpoint to return the complete updated user object in the response body, eliminating the frontend's need for an extra `GET` request to refresh its local state

## 🧪 How to test
1. Setup the environment
~~~bash
# Start development environment
docker compose --profile web up -d --build
~~~

~~~bash 
# Start testing environment
docker compose --profile test --env-file=.env.testing up -d --build
~~~

2. Run the test suite to verify all changes:
~~~bash
docker compose exec app_test php artisan test
~~~

3. Manual test for email validation (via Postman or cURL):
 - Attempt to register or update a profile with an invalid email (e.g., `user@example`) → should be rejected with validation error
 - Attempt with a valid email (e.g., `user@example.com`) → should be accepted

4. Manual test for profile update response:
   - Send a `PATCH` request to `/api/profile` with updated user data
   - Verify that the response body includes the full updated user object (not just a success message)

5. Manual test for login flash message (optional):
   - Authenticate with valid credentials
   - Verify that no success flash message is displayed after login

## 📘  Docs
API documentation can be viewed locally at:
http://localhost/docs/api#/

## 🔗 Related Issue
Closes #137 