### PR TITLE
bwogt/143/refactor/remove-handle-failure-from-actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,5 +21,14 @@ docker compose --profile web up -d --build
 docker compose --profile test --env-file=.env.testing up -d --build
 ~~~
 
+2. Run the test suite to verify all changes
+~~~bash
+docker compose exec app_test php artisan test
+~~~
+
+## 📘  Docs
+API documentation can be viewed locally at:
+http://localhost/docs/api#/
+
 ## 🔗 Related Issue
 Closes #**ISSUE_NUMBER**

--- a/app/Actions/Device/Delete/DeleteDeviceAction.php
+++ b/app/Actions/Device/Delete/DeleteDeviceAction.php
@@ -27,7 +27,13 @@ final class DeleteDeviceAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $device);
+            throw new DeleteDeviceFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'device_id' => $device->id,
+                ]
+            );
         }
     }
 
@@ -48,16 +54,5 @@ final class DeleteDeviceAction
             'user_id' => $user->id,
             'device_id' => $device->id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, Device $device): never
-    {
-        throw new DeleteDeviceFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'device_id' => $device->id,
-            ]
-        );
     }
 }

--- a/app/Actions/Device/Invalidate/InvalidateDeviceAction.php
+++ b/app/Actions/Device/Invalidate/InvalidateDeviceAction.php
@@ -28,7 +28,14 @@ final class InvalidateDeviceAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $device);
+            throw new InvalidateDeviceFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'device_id' => $device->id,
+                    'validation_status' => $device->validation_status,
+                ]
+            );
         }
     }
 
@@ -49,17 +56,5 @@ final class InvalidateDeviceAction
             'user_id' => $user->id,
             'device_id' => $device->id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, Device $device): never
-    {
-        throw new InvalidateDeviceFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'device_id' => $device->id,
-                'validation_status' => $device->validation_status,
-            ]
-        );
     }
 }

--- a/app/Actions/Device/Validate/StartDeviceValidationAction.php
+++ b/app/Actions/Device/Validate/StartDeviceValidationAction.php
@@ -30,7 +30,13 @@ final class StartDeviceValidationAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $device);
+            throw new StartDeviceValidationFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'device_id' => $device->id,
+                ]
+            );
         }
     }
 
@@ -60,16 +66,5 @@ final class StartDeviceValidationAction
             'user_id' => $user->id,
             'device_id' => $device->id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, Device $device): never
-    {
-        throw new StartDeviceValidationFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'device_id' => $device->id,
-            ]
-        );
     }
 }

--- a/app/Actions/DeviceTransfer/Accept/AcceptDeviceTransferAction.php
+++ b/app/Actions/DeviceTransfer/Accept/AcceptDeviceTransferAction.php
@@ -29,7 +29,13 @@ class AcceptDeviceTransferAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $transfer);
+            throw new AcceptDeviceTransferFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'transfer_id' => $transfer->id,
+                ]
+            );
         }
     }
 
@@ -56,16 +62,4 @@ class AcceptDeviceTransferAction
             'transfer_id' => $transfer->id,
         ]);
     }
-
-    private function handleFailure(Throwable $e, User $user, DeviceTransfer $transfer): never
-    {
-        throw new AcceptDeviceTransferFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'transfer_id' => $transfer->id,
-            ]
-        );
-    }
-
 }

--- a/app/Actions/DeviceTransfer/Cancel/CancelDeviceTransferAction.php
+++ b/app/Actions/DeviceTransfer/Cancel/CancelDeviceTransferAction.php
@@ -28,7 +28,13 @@ class CancelDeviceTransferAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $transfer);
+            throw new CancelDeviceTransferFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'transfer_id' => $transfer->id,
+                ]
+            );
         }
     }
 
@@ -49,16 +55,5 @@ class CancelDeviceTransferAction
             'user_id' => $user->id,
             'transfer_id' => $transfer->id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, DeviceTransfer $transfer): never
-    {
-        throw new CancelDeviceTransferFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'transfer_id' => $transfer->id,
-            ]
-        );
     }
 }

--- a/app/Actions/DeviceTransfer/Create/CreateDeviceTransferAction.php
+++ b/app/Actions/DeviceTransfer/Create/CreateDeviceTransferAction.php
@@ -29,7 +29,14 @@ final class CreateDeviceTransferAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $data);
+            throw new CreateDeviceTransferFailedException(
+                previous: $e,
+                context: [
+                    'device_id' => $data->device->id,
+                    'user_id' => $user->id,
+                    'target_user_id' => $data->targetUser->id,
+                ]
+            );
         }
     }
 
@@ -58,17 +65,5 @@ final class CreateDeviceTransferAction
             'user_id' => $transfer->source_user_id,
             'target_user_id' => $transfer->target_user_id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, CreateDeviceTransferDTO $data): never
-    {
-        throw new CreateDeviceTransferFailedException(
-            previous: $e,
-            context: [
-                'device_id' => $data->device->id,
-                'user_id' => $user->id,
-                'target_user_id' => $data->targetUser->id,
-            ]
-        );
     }
 }

--- a/app/Actions/DeviceTransfer/Reject/RejectDeviceTransferAction.php
+++ b/app/Actions/DeviceTransfer/Reject/RejectDeviceTransferAction.php
@@ -28,7 +28,13 @@ class RejectDeviceTransferAction
         } catch (BusinessRuleException $e) {
             throw $e;
         } catch (Throwable $e) {
-            $this->handleFailure($e, $user, $transfer);
+            throw new RejectDeviceTransferFailedException(
+                previous: $e,
+                context: [
+                    'user_id' => $user->id,
+                    'transfer_id' => $transfer->id,
+                ]
+            );
         }
     }
 
@@ -49,16 +55,5 @@ class RejectDeviceTransferAction
             'user_id' => $user->id,
             'transfer_id' => $transfer->id,
         ]);
-    }
-
-    private function handleFailure(Throwable $e, User $user, DeviceTransfer $transfer): never
-    {
-        throw new RejectDeviceTransferFailedException(
-            previous: $e,
-            context: [
-                'user_id' => $user->id,
-                'transfer_id' => $transfer->id,
-            ]
-        );
     }
 }


### PR DESCRIPTION
## Description
This PR removes the `handleFailure` pattern from all Actions where it was previously implemented. The `handleFailure` method acted as an unnecessary wrapper that rethrew domain-specific exceptions with additional context, adding complexity without providing real business value.

Some Actions already handled exceptions directly in the `catch (Throwable $e)` block (e.g., `LoginAction`), while others delegated to `handleFailure`. This inconsistency made the code harder to read and maintain.

The refactoring unifies the exception handling strategy across all Actions: each Action now catches `Throwable`, preserves the `BusinessRuleException` chain (rethrows as-is), and directly throws the domain-specific exception with the appropriate context and `previous` exception.

## 🔧 What was done
- Removed `handleFailure` method from all Actions
- Moved exception throwing logic directly into the `catch (Throwable $e)` block for each Action
- Updated pull request template

## 🧪 How to test
1. Setup the environment
~~~bash
# Start development environment
docker compose --profile web up -d --build
~~~

~~~bash 
# Start testing environment
docker compose --profile test --env-file=.env.testing up -d --build
~~~

2. Run the test suite to verify all changes
~~~bash
docker compose exec app_test php artisan test
~~~

## 📘  Docs
API documentation can be viewed locally at:
http://localhost/docs/api#/

## 🔗 Related Issue
Closes #143 