### PR TITLE
bwogt/147/feat/dashboard-stats

### DIFF
--- a/app/Http/Controllers/Dashboard/DashboardController.php
+++ b/app/Http/Controllers/Dashboard/DashboardController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Dashboard\DashboardResource;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class DashboardController extends Controller
+{
+    public function dashboard(): JsonResource
+    {
+        $user = request()->user();
+
+        $stats = $user->devices()
+            ->selectRaw('validation_status, count(*) as total')
+            ->groupBy('validation_status')
+            ->pluck('total', 'validation_status');
+
+        return DashboardResource::make($stats);
+    }
+}

--- a/app/Http/Resources/Dashboard/DashboardResource.php
+++ b/app/Http/Resources/Dashboard/DashboardResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources\Dashboard;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class DashboardResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'total' => $this->resource->sum(),
+            'pending' => $this->resource->get('pending', 0),
+            'validated' => $this->resource->get('validated', 0),
+            'rejected' => $this->resource->get('rejected', 0),
+            'in_analysis' => $this->resource->get('in_analysis', 0),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\AuthController;
 use App\Http\Controllers\Brand\BrandController;
+use App\Http\Controllers\Dashboard\DashboardController;
 use App\Http\Controllers\Device\DeviceController;
 use App\Http\Controllers\Device\DeviceShareController;
 use App\Http\Controllers\Device\DeviceTransferController;
@@ -39,6 +40,13 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::controller(AuthController::class)->group(function () {
         Route::delete('logout', 'logout')->name('api.auth.logout');
     });
+
+    Route::controller(DashboardController::class)
+        ->prefix('dashboard')
+        ->name('api.dashboard')
+        ->group(function () {
+            Route::get('/', 'dashboard');
+        });
 
     Route::controller(UserController::class)->group(function () {
         Route::patch('user', 'update')->name('api.user.update');

--- a/tests/Feature/Controllers/Dashboard/DashboardAccessTest.php
+++ b/tests/Feature/Controllers/Dashboard/DashboardAccessTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Feature\Controllers\Dashboard;
+
+final class DashboardAccessTest extends DashboardTestSetUp
+{
+    public function test_unauthenticated_user_cannot_access_dashboard(): void
+    {
+        $this->assertAccessUnauthorizedTo($this->route(), 'get');
+    }
+
+    public function test_authenticated_user_can_access_dashboard(): void
+    {
+        $this->assertAccessTo(
+            route: $this->route(),
+            httpVerb: 'get',
+            assertHttpResponse: 'assertOk',
+            users: [$this->user],
+        );
+    }
+}

--- a/tests/Feature/Controllers/Dashboard/DashboardResponseTest.php
+++ b/tests/Feature/Controllers/Dashboard/DashboardResponseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Controllers\Dashboard;
+
+use Illuminate\Testing\Fluent\AssertableJson;
+use Laravel\Sanctum\Sanctum;
+
+final class DashboardResponseTest extends DashboardTestSetUp
+{
+    public function test_returns_zeroed_dashboard_summary_when_user_has_no_devices(): void
+    {
+        Sanctum::actingAs($this->user);
+
+        $this->getJson($this->route())
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('total', 0)
+                ->where('validated', 0)
+                ->where('pending', 0)
+                ->where('rejected', 0)
+                ->where('in_analysis', 0)
+            );
+    }
+
+    public function test_returns_dashboard_summary_with_device_counts_by_status(): void
+    {
+        Sanctum::actingAs($this->user);
+        $this->generateDevices();
+
+        $this->getJson($this->route())
+            ->assertOk()
+            ->assertJson(fn (AssertableJson $json) => $json
+                ->where('total', 4)
+                ->where('validated', 1)
+                ->where('pending', 1)
+                ->where('rejected', 1)
+                ->where('in_analysis', 1)
+            );
+    }
+}

--- a/tests/Feature/Controllers/Dashboard/DashboardTestSetUp.php
+++ b/tests/Feature/Controllers/Dashboard/DashboardTestSetUp.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature\Controllers\Dashboard;
+
+use App\Models\User;
+use Database\Factories\DeviceFactory;
+use Database\Factories\UserFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Asserts\AccessAsserts;
+use Tests\TestCase;
+
+class DashboardTestSetUp extends TestCase
+{
+    use AccessAsserts;
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->userSetUp();
+    }
+
+    private function userSetUp(): void
+    {
+        $this->user = UserFactory::new()->create();
+    }
+
+    protected function generateDevices(): void
+    {
+        DeviceFactory::new()->for($this->user)->create();
+        DeviceFactory::new()->for($this->user)->inAnalysis()->create();
+        DeviceFactory::new()->for($this->user)->validated()->create();
+        DeviceFactory::new()->for($this->user)->rejected()->create();
+    }
+
+    protected function route(): string
+    {
+        return route('api.dashboard');
+    }
+}


### PR DESCRIPTION
## Description
This PR adds a new authenticated endpoint to provide aggregated device counts grouped by status. This endpoint will be used by the new frontend home page dashboard.

## 🔧 What was done
- Created `DashboardController` with the `dashboard` method
- Created `DashboardResource` to format the aggregated data
- Added route `api/dashboard` protected by authentication middleware
- Added feature tests covering access control and response structure

## 🧪 How to test
1. Setup the environment
~~~bash
# Start development environment
docker compose --profile web up -d 
~~~

~~~bash 
# Start testing environment
docker compose --profile test --env-file=.env.testing up -d 
~~~

2. Run the test suite to verify all changes
~~~bash
docker compose exec app_test php artisan test
~~~

## 📘  Docs
API documentation can be viewed locally at:
http://localhost/docs/api#/

## 🔗 Related Issue
Closes #147 